### PR TITLE
refactor: optimize queries for /omni-types

### DIFF
--- a/src/main/java/com/auto1/testdatastorage/domain/OmniType.java
+++ b/src/main/java/com/auto1/testdatastorage/domain/OmniType.java
@@ -28,4 +28,13 @@ public class OmniType {
     private LocalDateTime created;
     private LocalDateTime updated;
 
+    public interface OmniTypeWithCount {
+        Long getId();
+        String getDataType();
+        String getMeta();
+        LocalDateTime getCreated();
+        LocalDateTime getUpdated();
+        Long getCount();
+    }
+
 }

--- a/src/main/java/com/auto1/testdatastorage/mapping/EntityMapper.java
+++ b/src/main/java/com/auto1/testdatastorage/mapping/EntityMapper.java
@@ -30,6 +30,12 @@ public class EntityMapper {
         return omniTypeDTO;
     }
 
+    public static OmniTypeDTO toOmniTypeDTO(final OmniType.OmniTypeWithCount omniType) {
+        final OmniTypeDTO omniTypeDTO = new OmniTypeDTO();
+        copyProperties(omniType, omniTypeDTO);
+        return omniTypeDTO;
+    }
+
     public static OmniType toOmniType(final OmniTypeDTO omniTypeDTO) {
         final OmniType omniType = new OmniType();
         copyProperties(omniTypeDTO, omniType);

--- a/src/main/java/com/auto1/testdatastorage/repository/OmniTypeRepository.java
+++ b/src/main/java/com/auto1/testdatastorage/repository/OmniTypeRepository.java
@@ -22,4 +22,20 @@ public interface OmniTypeRepository
     @Query(value = "SELECT DISTINCT data_type FROM test_data_storage.omni_type ORDER BY data_type ASC", nativeQuery = true)
     List<String> findDistinctDataTypes();
 
+    @Query(value = "SELECT " +
+            "    id, " +
+            "    data_type AS dataType, " +
+            "    meta, " +
+            "    created, " +
+            "    updated, " +
+            "    COALESCE(count, 0) AS count " +
+            "FROM test_data_storage.omni_type " +
+            "LEFT JOIN ( " +
+            "    SELECT omni_type_id, COUNT(*) AS count " +
+            "    FROM test_data_storage.omni_queue " +
+            "    WHERE archived = false " +
+            "    GROUP BY omni_type_id " +
+            ") AS subquery ON omni_type.id = subquery.omni_type_id " +
+            "ORDER BY test_data_storage.omni_type.id ASC", nativeQuery = true)
+    List<OmniType.OmniTypeWithCount> findAllAndCount();
 }

--- a/src/main/java/com/auto1/testdatastorage/service/OmniTypeService.java
+++ b/src/main/java/com/auto1/testdatastorage/service/OmniTypeService.java
@@ -66,15 +66,8 @@ public class OmniTypeService {
 
     public List<OmniTypeDTO> getAllOmniTypes() {
         log.info("Get all omni types");
-        var omniTypes = omniTypeRepository.findAllByOrderByIdAsc();
-        List<OmniTypeDTO> omniTypeDTOS = omniTypes.stream()
+        return omniTypeRepository.findAllAndCount().stream()
                 .map(EntityMapper::toOmniTypeDTO)
-                .collect(Collectors.toList());
-
-        omniTypeDTOS.forEach(omniTypeDTO -> {
-            omniTypeDTO.setCount(this.omniRepository.countByOmniTypeAndArchived(EntityMapper.toOmniType(omniTypeDTO), false));
-        });
-
-        return omniTypeDTOS;
+                .collect(Collectors.toUnmodifiableList());
     }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -8,3 +8,6 @@ spring.flyway.locations=classpath:db/migration
 
 basic.username=user1
 basic.password=password
+
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
We were making `countByOmniTypeAndArchived` query for each of the 410 omni-types to get the count.
Substituted those with single query.
<img width="792" alt="Screenshot 2023-06-08 at 16 12 50" src="https://github.com/auto1-oss/test-data-storage-service/assets/12628880/f9a10e85-1d99-414d-b05f-0d4fa67a591d">
